### PR TITLE
Introduction of nullable type attribute

### DIFF
--- a/MSON Specification.md
+++ b/MSON Specification.md
@@ -439,6 +439,7 @@ Defines extra attributes associated with the implementation of a type.
 - `required` - instance of this type is required
 - `optional` - instance of this type is optional (default)
 - `fixed`    - instance of this type structure and values are fixed
+- `nullable` - instance of this type *Value* MAY be unset (e.g. `null` or `nil`)
 - `sample`   - Alternate way to indicate a _[Value][]_ is a sample. See _[Sample][]_.
 - `default`  - Alternate way to indicate a _[Value][]_ is a default. See _[Default][]_.
 

--- a/examples/nullable.md
+++ b/examples/nullable.md
@@ -1,0 +1,45 @@
+# Nullable type attribute
+
+The `nullable` type attribute can be used to outline the instance of this type *Value* MAY be unset (e.g. `null` or `nil`).
+
+## Unset a `string` or an `array` type
+
+### MSON
+
+```mson
+- keyA (string, nullable, required) - Value of this field can be either unset or of the `string` type
+- keyB (array, nullable, required) - Value of this field can be either unset or of the `array` type
+```
+
+### JSON
+
+```json
+{
+   "keyA": null,
+   "keyB": null
+}
+```
+
+```json
+{
+   "keyA": "bob",
+   "keyB": [1, 2, 3]
+}
+```
+
+## Unset a value in an `array` of strings
+
+### MSON
+
+```mson
+- keyA (array, required)  - Value of this array can be either unset or of the `string` type
+    - (string, nullable)
+```
+
+### JSON
+
+```json
+{
+    "keyA": ["dave", "cat", null, "house"]
+}
+```

--- a/rendering/nullable.md
+++ b/rendering/nullable.md
@@ -1,0 +1,96 @@
+# Rendering recommendation
+
+These are the recommendation for **rendering an instance of a `nullable` type without any other sample value provided**.
+
+### JavaScript, JSON, YAML
+
+`null` value
+
+### JSON Schema
+
+```json
+{ "type": [ "string", "null" ] }
+```
+
+(instance of a nullable string type)
+
+### XML
+
+`xsi:nil="true"` attribute
+
+### Swift, GO
+
+`nil` value
+
+### C++, C, PHP, SQL
+
+`NULL` value
+
+### Python
+
+`None` value
+
+### Ruby
+
+`nil` value
+
+### PERL
+
+`undef` value
+
+## Rendering with other type attributes
+
+### optional
+
+```mson
+- key (string, optional)
+```
+
+The instance of key will be omitted in the rendered JSON:
+
+```json
+{}
+```
+
+### optional, nullable
+
+```mson
+- key (string, optional, nullable)
+```
+
+The value of the instance will be unset in the rendered JSON:
+
+```json
+{
+  "key": null
+}
+```
+
+### required
+
+```mson
+- key (string, required)
+```
+
+The value of instance will be empty in the rendered JSON:
+
+```json
+{
+  "key": ""
+}
+```
+
+### required, nullable
+
+```mson
+- key (string, required, nullable)
+```
+
+The value of instance of key will be unset in the rendered JSON:
+
+```json
+{
+  "key": null
+}
+```
+


### PR DESCRIPTION
this resolves #26 and is consistent with the suggested solution in this [comment](https://github.com/apiaryio/mson/issues/26#issuecomment-135435209)

- introducing the `nullable` type attribute
- adding an example of how to use `nullable`
- adding a rendering folder with an example of how `nullable` should be used within tools

*This is a duplicate of #37 which was destroyed by a bad rebased. The code is the same.*