### PR TITLE
Update API Blueprint example

### DIFF
--- a/examples/api-blueprint.md
+++ b/examples/api-blueprint.md
@@ -1,24 +1,16 @@
 # Notes API
 
 ## Notes [/notes]
-+ Model
-
-    + Body (array[Note])
  
 ### List all [GET]
 + Response 200 (application/json)
- 
-    [Notes][]
+    + Attributes (array[Note])
  
 ## Note [/notes/{id}]
-+ Model
-
-    + Body (object)
- 
-        + id: 42 (number) - id of the note
-        + title: Buy Milk (string) - title of the note
++ Attributes
+    + id: 42 (number) - id of the note
+    + title: Buy Milk (string) - title of the note
   
 ### Retrieve a Note [GET]
 + Response 200 (application/json)
- 
-    [Note][]
+    + Attributes (Note)


### PR DESCRIPTION
The current syntax was not valid, seems it predates the syntax used in API Blueprint for MSON.