### PR TITLE
Use &ast; HTML entity inside italics blocks

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -37,7 +37,7 @@ We may also specify a sample value for the person's name by preceding the proper
 + name: Kyle (string) - The Person's name
 ```
 
-**NOTE**: *It's important to note, that if a sample value contains reserved characters such as `:`, `(`,`)`, `<`, `>`, `{`, `}`, `[`, `]`, `_`, `*`, `-`, `+`, `` ` `` then the sample value must be wrapped in a code-block using back-ticks:*
+**NOTE**: *It's important to note, that if a sample value contains reserved characters such as `:`, `(`,`)`, `<`, `>`, `{`, `}`, `[`, `]`, `_`, <code>&ast;</code>, `-`, `+`, `` ` `` then the sample value must be wrapped in a code-block using back-ticks:*
 
 ```apib
 + name: `Spencer-Churchill` (string) - The Person's name


### PR DESCRIPTION
Some Markdown renderers have issues with backticked asterisks inside italics blocks. See second note in [live MSON tutorial](https://apiblueprint.org/documentation/mson/tutorial.html).

I understand that this is actually a bug in the renderer and not in the Document but I noticed it on the MSON documentation page and found out it originates from here, hence the proposal for a temporary workaround.

Not trying to start a holy war here... :-)