### PR TITLE
Nullable may only be used as properties in objects

### DIFF
--- a/MSON Specification.md
+++ b/MSON Specification.md
@@ -442,7 +442,7 @@ Defines extra attributes associated with the implementation of a type.
 - `required` - instance of this type is required
 - `optional` - instance of this type is optional (default)
 - `fixed`    - instance of this type structure and values are fixed
-- `nullable` - instance of this type *Value* MAY be unset (e.g. `null` or `nil`)
+- `nullable` - instance of this type *Value* MAY be unset (e.g. `null` or `nil`). `nullable` may only be used within properties of objects.
 - `sample`   - Alternate way to indicate a _[Value][]_ is a sample. See _[Sample][]_.
 - `default`  - Alternate way to indicate a _[Value][]_ is a default. See _[Default][]_.
 


### PR DESCRIPTION
Nullable has only been implemented for properties in parsers (Snowcrash, Drafter) and thus is unsupported for other definitions.