### PR TITLE
Update specification example for mixed-type array

### DIFF
--- a/MSON Specification.md
+++ b/MSON Specification.md
@@ -675,7 +675,7 @@ By Default:
         - 5 (number)
     ```
 
-    Implies an `array` structure whose individual items MAY be strings or numbers with sample values "red" and "5",
+    Implies an `array` structure whose individual items MAY be strings or numbers with sample values "red" and 5,
     respectively.
 
 - Enum Structures


### PR DESCRIPTION
This declaration:

```mson
- colors (array)
    - red (string)
    - 5 (number)
```

is correctly described as implying an array that may contain strings or numbers; however, I believe the corresponding sample values should be "red" (as a string) and 5 (as a number), not "red" (as a string) and "5" (as a string). This is fixed by the current PR.