### PR TITLE
Use `fixed-type` to produce correct JSON Schema in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A product from Acme's catalog
 - id: 1 (number, required) - The unique identifier for a product
 - name: A green door (string, required) - Name of the product
 - price: 12.50 (number, required)
-- tags: home, green (array[string])
+- tags: home, green (array[string], fixed-type)
 
 #### JSON
 


### PR DESCRIPTION
This specific MSON example from the README shows the generated JSON Schema which has a fixed type. This pull request updates the MSON structure to use `fixed-type` to produce the correct JSON Schema.