### PR TITLE
Add fixed-type in example.

### DIFF
--- a/examples/api-blueprint.md
+++ b/examples/api-blueprint.md
@@ -4,7 +4,7 @@
  
 ### List all [GET]
 + Response 200 (application/json)
-    + Attributes (array[Note])
+    + Attributes (array[Note], fixed-type)
  
 ## Note [/notes/{id}]
 + Attributes


### PR DESCRIPTION
`fixed-type` forces correct behavior  rendering of array in JSON Schema  in Apiary. Without it renders as:
```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "array"
}
```